### PR TITLE
Add Fastmail mail DNS for salkeld.net

### DIFF
--- a/__main__.py
+++ b/__main__.py
@@ -58,6 +58,59 @@ def static_site(config: StaticSiteConfig):
     )
 
 
+def fastmail_dns():
+    for record_id, target, priority in [
+        ("mail-mx-primary", "in1-smtp.messagingengine.com", 10),
+        ("mail-mx-secondary", "in2-smtp.messagingengine.com", 20),
+    ]:
+        cloudflare.DnsRecord(
+            record_id,
+            name=domain_name,
+            proxied=False,
+            ttl=1,
+            type="MX",
+            content=target,
+            priority=priority,
+            zone_id=zone,
+        )
+
+    cloudflare.DnsRecord(
+        "mail-spf",
+        name=domain_name,
+        proxied=False,
+        ttl=1,
+        type="TXT",
+        content='"v=spf1 include:spf.messagingengine.com -all"',
+        zone_id=zone,
+    )
+
+    # DKIM must be DNS-only or Cloudflare proxying breaks the lookups
+    for n in (1, 2, 3):
+        cloudflare.DnsRecord(
+            f"mail-dkim-fm{n}",
+            name=f"fm{n}._domainkey.{domain_name}",
+            proxied=False,
+            ttl=1,
+            type="CNAME",
+            content=f"fm{n}.{domain_name}.dkim.fmhosted.com",
+            zone_id=zone,
+        )
+
+    # p=none is monitoring mode; tighten to quarantine/reject once reports look clean
+    cloudflare.DnsRecord(
+        "mail-dmarc",
+        name=f"_dmarc.{domain_name}",
+        proxied=False,
+        ttl=1,
+        type="TXT",
+        content=f'"v=DMARC1; p=none; rua=mailto:dmarc@{domain_name}"',
+        zone_id=zone,
+    )
+
+
+fastmail_dns()
+
+
 # main personal site
 personal = StaticSiteConfig()
 personal.build_config = {


### PR DESCRIPTION
Sets up salkeld.net to receive and send mail through Fastmail: MX records pointing at messagingengine.com, SPF with a hard fail (-all), the three fm1-3 DKIM CNAMEs, and a DMARC record.

DMARC is in monitoring mode (p=none, rua=mailto:dmarc@salkeld.net) so we collect reports without affecting delivery yet. Tighten to quarantine/reject once the reports look clean.

The DKIM CNAME targets (fmN.salkeld.net.dkim.fmhosted.com) only resolve once the domain is added to the Fastmail account, which is what provisions the keys. So DKIM will not validate until that is done - the records are correct, they just point at nothing yet.

Local pulumi preview showed 7 creates, 7 unchanged. CI runs the preview on this PR; deploy happens on merge.